### PR TITLE
fix: MySQLからPostgreSQLへのデータベースプロバイダー変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ポケモンコレクション
 
-ポケモンのコレクション管理アプリケーション。Nuxt 3 + Prisma + MySQL で構築。
+ポケモンのコレクション管理アプリケーション。Nuxt 3 + Prisma + PostgreSQL で構築。
 
 ## セットアップ
 
@@ -114,10 +114,51 @@ pokemon-collection/
     └── SOW_*.md        # 機能別仕様書
 ```
 
+## データベース構成
+
+### Vercel Storage (Prisma Postgres)
+
+本プロジェクトでは、Vercel Storage の Prisma Postgres を使用しています。
+
+#### 環境変数の設定
+
+```bash
+# .env ファイル
+DATABASE_URL="postgres://username:password@db.prisma.io:5432/?sslmode=require"
+```
+
+#### Vercel での設定手順
+
+1. **Vercel Storage でデータベース作成**
+   - Vercelプロジェクトの「Storage」タブ
+   - 「Create Database」→「Postgres」を選択
+   - データベース名とリージョンを設定
+
+2. **環境変数の自動設定**
+   - Vercel Storage 作成時に `DATABASE_URL` が自動設定される
+   - 本番・プレビュー・開発環境すべてに適用
+
+3. **ローカル開発での接続**
+   - Vercel Storage の接続文字列を `.env` ファイルにコピー
+   - `npx prisma db push` でスキーマを同期
+
+#### データベース移行履歴
+
+- **v1.0**: MySQL (ローカル環境)
+- **v2.0**: PostgreSQL (Vercel Storage/Prisma Postgres) ← 現行
+
+### 無料プランの制限
+
+- **ストレージ**: 512MB まで
+- **月間リクエスト**: 300万リクエスト
+- **同時接続数**: 60接続
+- **データ転送**: 5GB/月
+
 ## 開発メモ
 
 - ポケモンデータは Prisma でキャッシュし、PokeAPI への依存を削減
 - 開発時は`yarn dev`でホットリロードが有効
-- Vercel へのデプロイ設定済み（vercel.json）
+- Vercel Storage (Prisma Postgres) で本番運用
+- ESLint でコード品質を維持（self-closingルールは無効化）
 
 詳細な仕様は[Nuxt ドキュメント](https://nuxt.com/docs/getting-started/introduction)を参照。

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "mysql"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
feat: MySQL→PostgreSQL移行とリントエラー修正

  📋 Summary

Vercel StorageのPrisma PostgreSQLへの移行を実施しました。
本番環境でのデータベース接続エラーを解決し、コード品質を向上させました。

  🔧 Changes Made

  1. データベース移行 (MySQL → PostgreSQL)

  Prismaスキーマの更新

  datasource db {
  -  provider = "mysql"
  +  provider = "postgresql"
     url      = env("DATABASE_URL")
  }

  環境変数の設定

  - Vercel Storage (Prisma Postgres) の接続文字列を設定
  - .envファイルでローカル開発環境も対応

  データシード実行

  - 第1世代ポケモン151匹のデータを新しいPostgreSQLデータベースに投入完了
  - 全データの正常性を確認済み

 
  2. ドキュメント更新

  README.mdの充実

  - Vercel Storage設定手順の詳細
  - データベース移行履歴の記録
  - 無料プランの制限事項
  - 環境変数設定方法

  データベース接続

  ✅ PostgreSQL接続成功
  ✅ 第1世代ポケモン151匹シード完了
  ✅ API動作確認完了 (http://localhost:3000/api/pokemon/1)

  本番環境

  Before: 500 Server Error (DATABASE_URL not found)
  After:  ✅ 正常動作 (Vercel Storage接続)

  🎯 Technical Decisions

  なぜPostgreSQLを選択？

  - PlanetScaleの無料プラン終了により選択肢を検討
  - Vercel Storageとの統合が最もシンプル
  - 自動環境変数設定でデプロイが簡単

  🚀 Deployment

  本PRマージ後、Vercelで自動デプロイされ：
  1. 環境変数が自動設定される
  2. PostgreSQLデータベースに接続される
  3. ポケモンデータが正常表示される

  🔍 Test Plan
  - ローカル環境でリント実行 → エラー0件
  - 開発サーバー起動 → http://localhost:3000 正常動作
  - ポケモンAPI呼び出し → 日本語名・画像表示確認
  - データベースクエリ → 151匹全データ確認済み
  - Vercelプレビュー → 本番環境動作確認
<img width="1113" height="886" alt="スクリーンショット 2025-07-28 0 17 26" src="https://github.com/user-attachments/assets/b4959914-8328-475c-bb71-7fa2a2e44bf7" />

 <img width="637" height="778" alt="スクリーンショット 2025-07-28 0 19 10" src="https://github.com/user-attachments/assets/5478fe47-e6b8-4f57-ac55-91bdd9ff4afb" />
